### PR TITLE
Make neccessary compilation flag always presents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ERL_CFLAGS ?= -I$(ERL_EI_INCLUDE_DIR) -Ilibsass -Ilibsass/include
 ERL_LDFLAGS ?= -Ilibsass -Ilibsass/include -Llibsass/lib
 
 LDFLAGS += -fPIC -shared
-CFLAGS ?= -fPIC -O3 -Wall -Wextra
+CFLAGS += -fPIC -O3 -Wall -Wextra
 CC = $(CROSSCOMPILER)g++
 
 ifeq ($(CROSSCOMPILE),)


### PR DESCRIPTION
The `-fPIC` compilation flag is mandatory, without it final NIF compilation fails.
With `?=` this flag can be lost in case when CFLAGS defined in environment.