### PR TITLE
Fix and improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,23 +26,9 @@ ifeq ($(CROSSCOMPILE),)
 	endif
 endif
 
-NPROCS := 1
-OS := $(shell uname)
-export NPROCS
-
-ifeq ($J,)
-
-ifeq ($(OS),Linux)
-  NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
-else ifeq ($(OS),Darwin)
-  NPROCS := $(shell sysctl -n hw.logicalcpu)
-endif # $(OS)
-
-else
-  NPROCS := $J
-endif # $J
-
-all: libsass-make $(LIB_NAME)
+all:
+	$(MAKE) libsass-make
+	$(MAKE) $(LIB_NAME)
 
 clean: libsass-clean sass_compiler-clean
 
@@ -50,7 +36,7 @@ libsass-clean:
 	$(MAKE) -C $(SASS_DIR) clean
 
 libsass-make:
-	$(MAKE) -C $(SASS_DIR) -j$(NPROCS) -s
+	$(MAKE) -C $(SASS_DIR)
 
 %.o: %.c
 	$(CC) -x c++ -c $(ERL_CFLAGS) $(CFLAGS) -o $@ $<


### PR DESCRIPTION
important:
Make targets `libsass-make` and `$(LIB_NAME)` sequental instead of parallel.

also:
Remove `-s` for easy debugging subcommand
Remove `-j$(NPROCS)` because environment variable $MAKEFLAGS is enough
Remove NPROCS determining too
